### PR TITLE
Fix click duplication and yaml saving

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,8 +17,8 @@ def load_config(config_file_path: str = CONFIG_FILE_PATH):
 
 def save_config(config_file_path: str = CONFIG_FILE_PATH):
     global CONFIG
-    with open(config_file_path, "w") as f:
-        yaml.dump(CONFIG, f, default_flow_style=False, encoding='utf-8')
+    with open(config_file_path, "w", encoding="utf-8") as f:
+        yaml.dump(CONFIG, f, default_flow_style=False, allow_unicode=True)
 
 
 load_config()

--- a/helpers/scraper.py
+++ b/helpers/scraper.py
@@ -247,7 +247,6 @@ class Scraper:
                 if delay:
                     self.wait_action_random_time()
                 element.click()
-            element.click()
         except ElementClickInterceptedException:
             self.driver.execute_script("arguments[0].click();", element)
 


### PR DESCRIPTION
## Summary
- remove duplicate click call in scraper
- save YAML config without deprecated encoding argument

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d420cb40c8325827dd6c24b891962